### PR TITLE
Update state for Activity.ownBookmarks in Activity and Feed

### DIFF
--- a/Sources/StreamFeeds/StateLayer/ActivityState.swift
+++ b/Sources/StreamFeeds/StateLayer/ActivityState.swift
@@ -69,6 +69,21 @@ extension ActivityState {
                 await self?.access { state in
                     state.activity?.merge(with: activityData, update: reactionData, currentUserId: currentUserId)
                 }
+            case .bookmarkAdded(let bookmarkData):
+                guard bookmarkData.activity.id == activityId else { return }
+                await self?.access { state in
+                    state.activity?.merge(with: bookmarkData.activity, add: bookmarkData, currentUserId: currentUserId)
+                }
+            case .bookmarkDeleted(let bookmarkData):
+                guard bookmarkData.activity.id == activityId else { return }
+                await self?.access { state in
+                    state.activity?.merge(with: bookmarkData.activity, remove: bookmarkData, currentUserId: currentUserId)
+                }
+            case .bookmarkUpdated(let bookmarkData):
+                guard bookmarkData.activity.id == activityId else { return }
+                await self?.access { state in
+                    state.activity?.merge(with: bookmarkData.activity, update: bookmarkData, currentUserId: currentUserId)
+                }
             case .commentAdded(let commentData, let activityData, let eventFeedId):
                 guard activityData.id == activityId, eventFeedId == feed else { return }
                 await self?.access { state in

--- a/Sources/StreamFeeds/StateLayer/FeedState.swift
+++ b/Sources/StreamFeeds/StateLayer/FeedState.swift
@@ -170,7 +170,6 @@ extension FeedState {
                     }
                 }
             case .bookmarkAdded(let bookmarkData):
-                guard bookmarkData.activity.feeds.contains(feed.rawValue) else { return }
                 await self?.access { state in
                     state.activities.sortedUpdate(
                         ofId: bookmarkData.activity.id,
@@ -184,7 +183,6 @@ extension FeedState {
                     )
                 }
             case .bookmarkDeleted(let bookmarkData):
-                guard bookmarkData.activity.feeds.contains(feed.rawValue) else { return }
                 await self?.access { state in
                     state.activities.sortedUpdate(
                         ofId: bookmarkData.activity.id,
@@ -198,7 +196,6 @@ extension FeedState {
                     )
                 }
             case .bookmarkUpdated(let bookmarkData):
-                guard bookmarkData.activity.feeds.contains(feed.rawValue) else { return }
                 await self?.access { state in
                     state.activities.sortedUpdate(
                         ofId: bookmarkData.activity.id,


### PR DESCRIPTION
### 🔗 Issue Links

Related to: [IOS-1090](https://linear.app/stream/issue/IOS-1090) & [IOS-1122](https://linear.app/stream/issue/IOS-1122)


### 🎯 Goal

Own bookmarks did not update

### 📝 Summary

_Provide bullet points with the most important changes in the codebase._

### 🛠 Implementation

_Provide a detailed description of the implementation and explain your decisions if you find them relevant._

### 🎨 Showcase

_Add relevant screenshots and/or videos/gifs to easily see what this PR changes, if applicable._

| Before | After |
| ------ | ----- |
|  img   |  img  |

### 🧪 Manual Testing Notes

_Explain how this change can be tested manually, if applicable._

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [x] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo
