### PR TITLE
[CI] Bump Xcode to 26.2

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - ios: "26.1"
+          - ios: "26.2"
             device: "iPhone 17 Pro"
             setup_runtime: false
           - ios: "18.5"
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
     runs-on: macos-15
     env:
-      XCODE_VERSION: "26.1.1"
+      XCODE_VERSION: "26.2"
       IOS_SIMULATOR_DEVICE: "${{ matrix.device }} (${{ matrix.ios }})"
     steps:
     - uses: actions/checkout@v4.1.1
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - xcode: 26.1.1 # swift 6.2
+          - xcode: 26.2 # swift 6.2
             os: macos-15
           - xcode: 16.4 # swift 6.1
             os: macos-15

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -20,7 +20,7 @@ concurrency:
 
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
-  IOS_SIMULATOR_DEVICE: "iPhone 17 Pro (26.1)"
+  IOS_SIMULATOR_DEVICE: "iPhone 17 Pro (26.2)"
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_PR_NUM: ${{ github.event.pull_request.number }}
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -247,12 +247,12 @@ end
 
 lane :sources_matrix do
   {
-    llc: ['Sources/StreamFeeds', 'Tests/StreamFeedsTests', 'Tests/Shared', xcode_project],
-    sample_apps: ['Sources', 'DemoApp', xcode_project],
-    integration: ['Sources', 'Integration', xcode_project],
-    ruby: ['fastlane', 'Gemfile', 'Gemfile.lock'],
-    size: ['Sources', xcode_project],
-    public_interface: ['Sources']
+    llc: ['Sources/StreamFeeds', 'Tests/StreamFeedsTests', 'Tests/Shared', '.github/workflows/smoke-checks.yml', xcode_project],
+    sample_apps: ['Sources', 'DemoApp', '.github/workflows/smoke-checks.yml', xcode_project],
+    integration: ['Sources', 'Integration', '.github/workflows/smoke-checks.yml', xcode_project],
+    ruby: ['fastlane', 'Gemfile', 'Gemfile.lock', '.github/workflows/smoke-checks.yml'],
+    size: ['Sources', '.github/workflows/smoke-checks.yml', xcode_project],
+    public_interface: ['Sources', '.github/workflows/smoke-checks.yml']
   }
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,7 +6,7 @@ require 'json'
 require 'net/http'
 import 'Sonarfile'
 
-xcode_version = ENV['XCODE_VERSION'] || '26.1.1'
+xcode_version = ENV['XCODE_VERSION'] || '26.2'
 xcode_project = 'StreamFeeds.xcodeproj'
 sdk_names = ['StreamFeeds']
 github_repo = ENV['GITHUB_REPOSITORY'] || 'GetStream/stream-feeds-swift'


### PR DESCRIPTION
### 🔗 Issue Links

Resolve https://linear.app/stream/issue/IOS-1381/

### Test

- [x] [Cron checks passed](https://github.com/GetStream/stream-feeds-swift/actions/runs/21953263872)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and testing infrastructure to use Xcode 26.2 and iOS simulator version 26.2 for improved compatibility and reliability across development and testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->