### PR TITLE
[CI] Fix iOS 15 setup

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -33,7 +33,7 @@ jobs:
           - ios: "16.4"
             device: "iPhone 14 Pro"
             setup_runtime: true
-          - ios: "15.5"
+          - ios: "15.4"
             device: "iPhone 13 Pro"
             setup_runtime: true
       fail-fast: false


### PR DESCRIPTION
The installation of iOS 15.5 Simulator on CI started failing, so changing it to 15.4.

Test: https://github.com/GetStream/stream-core-swift/actions/runs/22310306810/job/64540285417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing configuration for iOS device compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->