### PR TITLE
Fix Sendable errors in Sort when building with Xcode 27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # Upcoming
 
 ### 🔄 Changed
+- Update StreamCore to 0.7.0, which fixes `Sendable` errors when building with Xcode 27 [#68](https://github.com/GetStream/stream-feeds-swift/pull/68)
 
 # [0.5.2](https://github.com/GetStream/stream-feeds-swift/releases/tag/0.5.2)
 _February 09, 2026_

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/GetStream/stream-core-swift.git", from: "0.6.3")
+        .package(url: "https://github.com/GetStream/stream-core-swift.git", from: "0.7.0")
     ],
     targets: [
         .target(

--- a/Sources/StreamFeeds/StateLayer/PaginatedLists/ActivitiesQuery.swift
+++ b/Sources/StreamFeeds/StateLayer/PaginatedLists/ActivitiesQuery.swift
@@ -220,7 +220,7 @@ public struct ActivitiesSortField: SortField {
     /// - Parameters:
     ///   - rawValue: The string value representing the field name in the API.
     ///   - localValue: A closure that extracts the comparable value from the model.
-    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable {
+    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable & Sendable {
         comparator = AnySortComparator(localValue: localValue)
         self.rawValue = rawValue
     }

--- a/Sources/StreamFeeds/StateLayer/PaginatedLists/ActivityReactionsQuery.swift
+++ b/Sources/StreamFeeds/StateLayer/PaginatedLists/ActivityReactionsQuery.swift
@@ -157,7 +157,7 @@ public struct ActivityReactionsSortField: SortField {
     /// - Parameters:
     ///   - rawValue: The string value representing the field name in the API.
     ///   - localValue: A closure that extracts the comparable value from the model.
-    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable {
+    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable & Sendable {
         comparator = AnySortComparator(localValue: localValue)
         self.rawValue = rawValue
     }

--- a/Sources/StreamFeeds/StateLayer/PaginatedLists/BookmarkFoldersQuery.swift
+++ b/Sources/StreamFeeds/StateLayer/PaginatedLists/BookmarkFoldersQuery.swift
@@ -161,7 +161,7 @@ public struct BookmarkFoldersSortField: SortField {
     /// - Parameters:
     ///   - rawValue: The string value representing the field name in the API.
     ///   - localValue: A closure that extracts the comparable value from the model.
-    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable {
+    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable & Sendable {
         comparator = AnySortComparator(localValue: localValue)
         self.rawValue = rawValue
     }

--- a/Sources/StreamFeeds/StateLayer/PaginatedLists/BookmarksQuery.swift
+++ b/Sources/StreamFeeds/StateLayer/PaginatedLists/BookmarksQuery.swift
@@ -166,7 +166,7 @@ public struct BookmarksSortField: SortField {
     /// - Parameters:
     ///   - rawValue: The string value representing the field name in the API.
     ///   - localValue: A closure that extracts the comparable value from the model.
-    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable {
+    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable & Sendable {
         comparator = AnySortComparator(localValue: localValue)
         self.rawValue = rawValue
     }

--- a/Sources/StreamFeeds/StateLayer/PaginatedLists/CommentReactionsQuery.swift
+++ b/Sources/StreamFeeds/StateLayer/PaginatedLists/CommentReactionsQuery.swift
@@ -164,7 +164,7 @@ public struct CommentReactionsSortField: SortField {
     /// - Parameters:
     ///   - rawValue: The string value representing the field name in the API.
     ///   - localValue: A closure that extracts the comparable value from the model.
-    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable {
+    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable & Sendable {
         comparator = AnySortComparator(localValue: localValue)
         self.rawValue = rawValue
     }

--- a/Sources/StreamFeeds/StateLayer/PaginatedLists/FeedsQuery.swift
+++ b/Sources/StreamFeeds/StateLayer/PaginatedLists/FeedsQuery.swift
@@ -256,7 +256,7 @@ public struct FeedsSortField: SortField {
     /// The string value representing the field name in the API for remote sorting.
     public let rawValue: String
     
-    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable {
+    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable & Sendable {
         comparator = AnySortComparator(localValue: localValue)
         self.rawValue = rawValue
     }

--- a/Sources/StreamFeeds/StateLayer/PaginatedLists/FollowsQuery.swift
+++ b/Sources/StreamFeeds/StateLayer/PaginatedLists/FollowsQuery.swift
@@ -156,7 +156,7 @@ public struct FollowsSortField: SortField {
     /// - Parameters:
     ///   - rawValue: The string value representing the field name in the API.
     ///   - localValue: A closure that extracts the comparable value from the model.
-    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable {
+    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable & Sendable {
         comparator = AnySortComparator(localValue: localValue)
         self.rawValue = rawValue
     }

--- a/Sources/StreamFeeds/StateLayer/PaginatedLists/MembersQuery.swift
+++ b/Sources/StreamFeeds/StateLayer/PaginatedLists/MembersQuery.swift
@@ -175,7 +175,7 @@ public struct MembersSortField: SortField {
     /// - Parameters:
     ///   - rawValue: The string value representing the field name in the API.
     ///   - localValue: A closure that extracts the comparable value from the model.
-    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable {
+    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable & Sendable {
         comparator = AnySortComparator(localValue: localValue)
         self.rawValue = rawValue
     }

--- a/Sources/StreamFeeds/StateLayer/PaginatedLists/ModerationConfigsQuery.swift
+++ b/Sources/StreamFeeds/StateLayer/PaginatedLists/ModerationConfigsQuery.swift
@@ -177,7 +177,7 @@ public struct ModerationConfigsSortField: SortField {
     /// - Parameters:
     ///   - rawValue: The string value representing the field name in the API.
     ///   - localValue: A closure that extracts the comparable value from the model.
-    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable {
+    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable & Sendable {
         comparator = AnySortComparator(localValue: localValue)
         self.rawValue = rawValue
     }

--- a/Sources/StreamFeeds/StateLayer/PaginatedLists/PollVotesQuery.swift
+++ b/Sources/StreamFeeds/StateLayer/PaginatedLists/PollVotesQuery.swift
@@ -187,7 +187,7 @@ public struct PollVotesSortField: SortField {
     /// - Parameters:
     ///   - rawValue: The string value representing the field name in the API.
     ///   - localValue: A closure that extracts the comparable value from the model.
-    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable {
+    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable & Sendable {
         comparator = AnySortComparator(localValue: localValue)
         self.rawValue = rawValue
     }

--- a/Sources/StreamFeeds/StateLayer/PaginatedLists/PollsQuery.swift
+++ b/Sources/StreamFeeds/StateLayer/PaginatedLists/PollsQuery.swift
@@ -197,7 +197,7 @@ public struct PollsSortField: SortField {
     /// - Parameters:
     ///   - rawValue: The string value representing the field name in the API.
     ///   - localValue: A closure that extracts the comparable value from the model.
-    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable {
+    public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable & Sendable {
         comparator = AnySortComparator(localValue: localValue)
         self.rawValue = rawValue
     }

--- a/StreamFeeds.xcodeproj/project.pbxproj
+++ b/StreamFeeds.xcodeproj/project.pbxproj
@@ -863,8 +863,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-core-swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.6.3;
+				branch = dev/xcode27;
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/StreamFeeds.xcodeproj/project.pbxproj
+++ b/StreamFeeds.xcodeproj/project.pbxproj
@@ -863,8 +863,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/GetStream/stream-core-swift.git";
 			requirement = {
-				branch = dev/xcode27;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.7.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Tests/StreamFeedsTests/Extensions/ArrayExtensions_Tests.swift
+++ b/Tests/StreamFeedsTests/Extensions/ArrayExtensions_Tests.swift
@@ -23,7 +23,7 @@ struct ArrayExtensions_Tests {
         public let comparator: AnySortComparator<Model>
         public let rawValue: String
         
-        public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable {
+        public init<Value>(_ rawValue: String, localValue: @escaping @Sendable (Model) -> Value) where Value: Comparable & Sendable {
             comparator = AnySortComparator(localValue: localValue)
             self.rawValue = rawValue
         }


### PR DESCRIPTION
### 🔗 Issue Links

https://linear.app/stream/issue/IOS-1751/xcode-27-compatibility-for-chat

### 🎯 Goal

Make StreamFeeds build with Xcode 27, which reports Sendable errors in the sort field types.

### 📝 Summary

- Constrain the generic `Value` in all `SortField` initializers to `Comparable & Sendable`, since the value is produced by a `@Sendable` closure.
- Temporarily point the StreamCore package in the Xcode project to the `dev/xcode27` branch, which contains the matching fix (GetStream/stream-core-swift#52).

### 🛠 Implementation

Same change as in StreamCore: the `localValue` closure passed to sort field initializers is `@Sendable`, so Xcode 27 requires the returned `Value` to be `Sendable` as well. Applied to all paginated list query sort fields and the test helper.

`Package.swift` is unchanged (still `from: 0.6.3`); only the Xcode project reference is pinned to the StreamCore `dev/xcode27` branch and should be switched back to a versioned requirement once the fix ships in a StreamCore release.

### 🧪 Manual Testing Notes

Build the package and run the tests with Xcode 27.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change should be manually QAed
- [x] Changelog is updated with client-facing changes
- [ ] Changelog is updated with new localization keys
- [ ] New code is covered by unit tests
- [ ] Documentation has been updated in the `docs-content` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tightened type-safety for various sort field initializers to improve reliability of local sorting behavior.

* **Tests**
  * Updated test fixtures to match the new type constraints.

* **Chores**
  * Bumped a core dependency version requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->