### PR TITLE
Fix TestFlight DemoApp upload

### DIFF
--- a/DemoApp/FeedsView/Mentions/CommandsHandler.swift
+++ b/DemoApp/FeedsView/Mentions/CommandsHandler.swift
@@ -87,7 +87,7 @@ extension CommandHandler {
 }
 
 /// Model for the composer's commands.
-public struct ComposerCommand {
+public struct ComposerCommand: Sendable {
     /// Identifier of the command.
     public let id: String
     /// Typing suggestion that invokes the command.
@@ -124,7 +124,7 @@ public struct SuggestionInfo: @unchecked Sendable {
 }
 
 /// Display information about a command.
-public struct CommandDisplayInfo {
+public struct CommandDisplayInfo: @unchecked Sendable {
     public let displayName: String
     public let icon: UIImage
     public let format: String

--- a/DemoApp/FeedsView/Mentions/CommandsHandler.swift
+++ b/DemoApp/FeedsView/Mentions/CommandsHandler.swift
@@ -124,7 +124,7 @@ public struct SuggestionInfo: @unchecked Sendable {
 }
 
 /// Display information about a command.
-public struct CommandDisplayInfo: @unchecked Sendable {
+public struct CommandDisplayInfo: Sendable {
     public let displayName: String
     public let icon: UIImage
     public let format: String

--- a/DemoApp/FeedsView/Mentions/TypingSuggester.swift
+++ b/DemoApp/FeedsView/Mentions/TypingSuggester.swift
@@ -33,7 +33,7 @@ public struct TypingSuggestionOptions {
 }
 
 /// A structure that contains the information of the typing suggestion.
-public struct TypingSuggestion {
+public struct TypingSuggestion: Sendable {
     /// A String representing the currently typing text.
     public let text: String
     /// A NSRange that stores the location of the typing suggestion in relation with the whole input.

--- a/DemoApp/Info.plist
+++ b/DemoApp/Info.plist
@@ -59,5 +59,12 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Add the iPad-specific supported orientations required for iPad multitasking to the DemoApp plist.
- Mark the demo app command suggestion models as Sendable so the Swift 6 DemoApp build used for verification succeeds.



Linear: https://linear.app/stream/issue/IOS-1752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full interface orientation support for iPad, including portrait and landscape display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->