### PR TITLE
CI: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -16,7 +16,6 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 permissions:
-  actions: write
   contents: read
 
 jobs:

--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -15,6 +15,10 @@ env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   build-and-test:
     name: Test LLC

--- a/.github/workflows/release-merge.yml
+++ b/.github/workflows/release-merge.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   merge-release-to-main:

--- a/.github/workflows/release-merge.yml
+++ b/.github/workflows/release-merge.yml
@@ -6,6 +6,10 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   merge-release-to-main:
     name: Merge release to main

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -3,6 +3,9 @@ name: "Publish new release"
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Publish new release

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -8,6 +8,10 @@ on:
         type: string
         required: true
 
+permissions:
+  actions: write
+  contents: write
+
 jobs:
   test-release:
     name: Start new release

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -9,8 +9,8 @@ on:
         required: true
 
 permissions:
-  actions: write
   contents: write
+  pull-requests: write
 
 jobs:
   test-release:

--- a/.github/workflows/sdk-size-metrics.yml
+++ b/.github/workflows/sdk-size-metrics.yml
@@ -13,6 +13,7 @@ env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
 
 permissions:
+  actions: write
   contents: read
   pull-requests: read
 

--- a/.github/workflows/sdk-size-metrics.yml
+++ b/.github/workflows/sdk-size-metrics.yml
@@ -12,6 +12,10 @@ on:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   sdk_size:
     name: Metrics

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -27,7 +27,7 @@ env:
 permissions:
   actions: write
   contents: read
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   guard:

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -25,9 +25,8 @@ env:
   GITHUB_PR_NUM: ${{ github.event.pull_request.number }}
 
 permissions:
-  actions: write
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   guard:

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -24,6 +24,11 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_PR_NUM: ${{ github.event.pull_request.number }}
 
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+
 jobs:
   guard:
     name: Guard

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -12,6 +12,9 @@ concurrency:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   sonar:
     runs-on: macos-15

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -13,6 +13,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 permissions:
+  actions: read
   contents: read
 
 jobs:

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -24,7 +24,7 @@ env:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   deploy:

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -22,6 +22,10 @@ on:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   deploy:
     runs-on: macos-15

--- a/.github/workflows/update-copyright.yml
+++ b/.github/workflows/update-copyright.yml
@@ -11,7 +11,8 @@ env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   copyright:

--- a/.github/workflows/update-copyright.yml
+++ b/.github/workflows/update-copyright.yml
@@ -10,6 +10,9 @@ on:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
 
+permissions:
+  contents: read
+
 jobs:
   copyright:
     name: Copyright


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions` blocks to workflow files flagged by CodeQL.
- Scopes derived from workflow operations (build, artifacts, Danger, release git push).
- Resolves **17** open `actions/missing-workflow-permissions` alerts.

## Linear
- Parent: [APPSEC-164](https://linear.app/stream/issue/APPSEC-164)

## Test plan
- [ ] CI green
- [ ] Code scanning alerts close after merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated multiple automation workflows to define explicit, least-privilege GitHub Actions token permissions at the workflow level.
  * Release, merge, testing, metrics, static analysis, smoke checks, maintenance, and SDK sizing workflows now run with scoped access rather than default permissions, improving security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->