### PR TITLE
[CI] Add verbose input to smoke and cron checks

### DIFF
--- a/.github/workflows/cron-checks.yml
+++ b/.github/workflows/cron-checks.yml
@@ -6,6 +6,12 @@ on:
     - cron: '0 4 * * 1-5'
 
   workflow_dispatch:
+    inputs:
+      verbose:
+        description: 'Run tests in verbose mode?'
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,6 +20,7 @@ concurrency:
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  VERBOSE: ${{ github.event.inputs.verbose == 'true' && '--verbose' || '' }}
 
 permissions:
   contents: read
@@ -54,7 +61,7 @@ jobs:
         version: ${{ matrix.ios }}
         device: ${{ matrix.device }}
     - name: Run LLC Tests (Debug)
-      run: bundle exec fastlane test device:"${{ env.IOS_SIMULATOR_DEVICE }}" cron:true
+      run: bundle exec fastlane test device:"${{ env.IOS_SIMULATOR_DEVICE }}" cron:true ${{ env.VERBOSE }}
       timeout-minutes: 60
     - name: Parse xcresult
       if: failure()
@@ -87,7 +94,7 @@ jobs:
     - uses: ./.github/actions/ruby-cache
     - uses: ./.github/actions/xcode-cache
     - name: Build Demo App
-      run: bundle exec fastlane build_demo
+      run: bundle exec fastlane build_demo ${{ env.VERBOSE }}
       env:
         XCODE_VERSION: ${{ matrix.xcode }}
 

--- a/.github/workflows/sdk-size-metrics.yml
+++ b/.github/workflows/sdk-size-metrics.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
 
   workflow_dispatch:
+    inputs:
+      verbose:
+        description: 'Run in verbose mode?'
+        type: boolean
+        required: false
+        default: false
 
   push:
     branches:
@@ -11,6 +17,7 @@ on:
 
 env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1 # Disable cleanup for homebrew, we don't need it on CI
+  VERBOSE: ${{ github.event.inputs.verbose == 'true' && '--verbose' || '' }}
 
 permissions:
   actions: write
@@ -47,5 +54,5 @@ jobs:
           APPSTORE_API_KEY: ${{ secrets.APPSTORE_API_KEY }}
 
       - name: Run Detailed SDK Size Metrics
-        run: bundle exec fastlane size_analyze
+        run: bundle exec fastlane size_analyze ${{ env.VERBOSE }}
         timeout-minutes: 30

--- a/.github/workflows/smoke-checks.yml
+++ b/.github/workflows/smoke-checks.yml
@@ -13,6 +13,11 @@ on:
         type: boolean
         required: false
         default: false
+      verbose:
+        description: 'Run tests in verbose mode?'
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,6 +28,7 @@ env:
   IOS_SIMULATOR_DEVICE: "iPhone 17 Pro (26.2)"
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_PR_NUM: ${{ github.event.pull_request.number }}
+  VERBOSE: ${{ github.event.inputs.verbose == 'true' && '--verbose' || '' }}
 
 permissions:
   contents: read
@@ -51,7 +57,7 @@ jobs:
         INSTALL_YEETD: true
         INSTALL_SONAR: true
     - name: Run LLC Tests (Debug)
-      run: bundle exec fastlane test device:"${{ env.IOS_SIMULATOR_DEVICE }}"
+      run: bundle exec fastlane test device:"${{ env.IOS_SIMULATOR_DEVICE }}" ${{ env.VERBOSE }}
       timeout-minutes: 40
     - name: Run Sonar analysis
       run: bundle exec fastlane sonar_upload
@@ -110,7 +116,7 @@ jobs:
     - uses: ./.github/actions/ruby-cache
     - uses: ./.github/actions/xcode-cache
     - name: Build Demo App
-      run: bundle exec fastlane build_demo device:"${{ env.IOS_SIMULATOR_DEVICE }}"
+      run: bundle exec fastlane build_demo device:"${{ env.IOS_SIMULATOR_DEVICE }}" ${{ env.VERBOSE }}
 
   build-spm-integration:
     name: Build SPM Integration App
@@ -121,4 +127,4 @@ jobs:
     - uses: ./.github/actions/ruby-cache
     - uses: ./.github/actions/xcode-cache
     - name: Build SPM Integration App
-      run: bundle exec fastlane spm_integration
+      run: bundle exec fastlane spm_integration ${{ env.VERBOSE }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,6 +15,7 @@ source_packages_path = 'spm_cache'
 swift_environment_path = File.absolute_path("../Sources/#{sdk_names.first}/Utils/SystemEnvironment+Version.swift")
 is_localhost = !is_ci
 @force_check = false
+xcodebuild_formatter = FastlaneCore::Globals.verbose? ? '' : nil
 
 before_all do |lane|
   if is_ci
@@ -119,7 +120,8 @@ lane :test do |options|
     number_of_retries: 3,
     skip_build: options[:skip_build],
     build_for_testing: options[:build_for_testing],
-    parallel_testing: !options[:cron]
+    parallel_testing: !options[:cron],
+    xcodebuild_formatter: xcodebuild_formatter
   }
 
   begin
@@ -199,7 +201,8 @@ private_lane :build_example_app do |options|
     derived_data_path: derived_data_path,
     cloned_source_packages_path: source_packages_path,
     build_for_testing: true,
-    devices: options[:device]
+    devices: options[:device],
+    xcodebuild_formatter: xcodebuild_formatter
   )
 end
 
@@ -215,7 +218,8 @@ lane :spm_integration do
     clean: is_localhost,
     derived_data_path: derived_data_path,
     cloned_source_packages_path: source_packages_path,
-    destination: 'generic/platform=iOS Simulator'
+    destination: 'generic/platform=iOS Simulator',
+    xcodebuild_formatter: xcodebuild_formatter
   )
 end
 
@@ -361,7 +365,8 @@ lane :size_analyze do
     skip_package_pkg: true,
     skip_codesigning: true,
     derived_data_path: derived_data_path,
-    cloned_source_packages_path: source_packages_path
+    cloned_source_packages_path: source_packages_path,
+    xcodebuild_formatter: xcodebuild_formatter
   )
 
   show_detailed_sdk_size(sdk_names: sdk_names, threshold: 42)


### PR DESCRIPTION
### 🎯 Goal

When a CI test job fails for a non-obvious reason, get the unfiltered `xcodebuild` output without having to edit the workflow, push, and wait.

### 🛠 Implementation

- New `workflow_dispatch` input `verbose` (boolean, **default `false`**) on `smoke-checks.yml` and `cron-checks.yml`.
- One workflow-level env instead of repeating the expression per step:
  ```yaml
  VERBOSE: ${{ github.event.inputs.verbose == 'true' && '--verbose' || '' }}
  ```
  appended as `${{ env.VERBOSE }}` to the test steps only (build-only steps are left alone).
- `Fastfile` bridges the flag into `scan`, so `--verbose` also stops the output being formatted:
  ```ruby
  xcodebuild_formatter = FastlaneCore::Globals.verbose? ? '' : nil
  ```
  passed to the `scan` calls of the test lanes. No lane option needed — fastlane sets `Globals.verbose` from `ARGV` before the `Fastfile` is loaded.

On `pull_request` / `schedule` runs the input is absent, the expression yields `''`, and both the commands and the `scan` config are identical to today (`nil` keeps fastlane's default formatter).

### 🧐 Why `xcodebuild_formatter: ''` and not `output_style: 'raw'`

Both drop the formatter, but who writes `test_output/report.junit` depends on the *resolved* formatter: xcpretty's pipe when it resolves to `xcpretty`, otherwise trainer parsing the xcresult. `output_style: 'raw'` removes the pipe while leaving the resolved formatter at `xcpretty`, so no junit is written and the `retreive_failed_tests` retry path dies with "There is no junit report to parse", masking the real failure. `xcodebuild_formatter: ''` moves junit generation to trainer, so retries keep working. This matters because the default is dynamic — `xcbeautify` if installed, else `xcpretty`.

### 🧪 Verification

- Probed the repo's own fastlane (2.228.0) with a real `Scan.config`: unset → resolved `"xcpretty"`, pipe `| tee <log> | xcpretty --report junit …`; `''` → resolved `""`, pipe `| tee <log>` only, junit via trainer.
- `bundle exec fastlane rubocop` clean; workflows parse as YAML.
- No new secret exposure: no secret is passed as a CLI arg or into xcodebuild by these lanes, `--verbose` does not dump `ENV`, fastlane masks `sensitive:` config items, and raw xcodebuild output echoes build settings rather than the runner environment.

Same change is being applied across the iOS SDK repos.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional verbose mode to manually triggered smoke and scheduled checks.
  * Verbose runs now provide more detailed test output.

* **Improvements**
  * Updated test execution formatting so verbose runs preserve detailed build output, while standard runs retain the default formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->