### PR TITLE
[CI] Lint Package.swift before release and verify it after release

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -33,8 +33,8 @@ jobs:
 
       - name: Integration Test
         run: | # reports to @support on failure
-          version=$(gh release view --repo ${{ github.repository }} --json tagName --jq .tagName)
-          gh workflow run test.yml --repo GetStream/apple-internal-testing-pipeline --field sdk=stream-feeds-swift --field version="$version"
+          test -n "$RELEASE_VERSION"
+          gh workflow run test.yml --repo GetStream/apple-internal-testing-pipeline --field sdk=stream-feeds-swift --field version="$RELEASE_VERSION"
         env:
           GITHUB_TOKEN: ${{ secrets.CI_BOT_GITHUB_TOKEN }}
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -31,6 +31,13 @@ jobs:
           APPSTORE_API_KEY: ${{ secrets.APPSTORE_API_KEY }}
         run: bundle exec fastlane publish_release --verbose
 
+      - name: Integration Test
+        run: | # reports to @support on failure
+          version=$(gh release view --repo ${{ github.repository }} --json tagName --jq .tagName)
+          gh workflow run test.yml --repo GetStream/apple-internal-testing-pipeline --field sdk=stream-feeds-swift --field version="$version"
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_BOT_GITHUB_TOKEN }}
+
   merge-main-to-develop:
     name: Merge main to develop
     runs-on: ubuntu-latest

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,7 +206,7 @@ GEM
       bundler
       fastlane
       pry
-    fastlane-plugin-stream_actions (0.4.7)
+    fastlane-plugin-stream_actions (0.4.8)
       xctest_list (= 1.2.1)
     fastlane-plugin-versioning (0.7.1)
     fastlane-plugin-xcsize (1.2.0)
@@ -403,7 +403,7 @@ DEPENDENCIES
   danger-commit_lint
   fastlane
   fastlane-plugin-lizard
-  fastlane-plugin-stream_actions (= 0.4.7)
+  fastlane-plugin-stream_actions (= 0.4.8)
   fastlane-plugin-versioning
   fastlane-plugin-xcsize (= 1.2.0)
   json

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -67,6 +67,7 @@ lane :publish_release do |options|
   release_version = get_sdk_version_from_environment
   UI.user_error!("Release #{release_version} has already been published.") if git_tag_exists(tag: release_version, remote: true)
   UI.user_error!('Release version cannot be empty') if release_version.to_s.empty?
+  File.write(ENV['GITHUB_ENV'], "RELEASE_VERSION=#{release_version}\n", mode: 'a') if ENV['GITHUB_ENV']
 
   ensure_git_branch(branch: 'main')
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,8 +35,9 @@ lane :release do |options|
     File.open(swift_environment_path, 'w') { |f| f.puts(new_content) }
   end
 
+  lint_swift_package
   check_unsafe_flags
-  match_me
+
   release_ios_sdk(
     version: options[:version],
     bump_type: options[:type],

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,5 +3,5 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-versioning'
-gem 'fastlane-plugin-stream_actions', '0.4.7'
+gem 'fastlane-plugin-stream_actions', '0.4.8'
 gem 'fastlane-plugin-xcsize', '1.2.0'


### PR DESCRIPTION
Resolves: https://linear.app/stream/issue/IOS-1934
Resolves: https://linear.app/stream/issue/IOS-1741

### 🎯 Goal

Verify package health at both ends of a release: block bad `Package.swift` pins **before** publishing, and integration-test the actually released versions **after** publishing (until now the post-release pipeline run tested develop tips).

### 🛠 Implementation

- Bump `fastlane-plugin-stream_actions` to 0.4.8, which brings the new `lint_swift_package` action and a default changelog entry when a release section is empty (IOS-1741).
- The `release` lane now runs `lint_swift_package` — it fails on branch/revision pins, version ranges, local-path deps, non-https urls, and duplicates in `Package.swift`; only `from:`/`exact:` pins pass.
- `release-publish.yml` passes `sdk` + the just-published version (from `gh release view`) to [apple-internal-testing-pipeline](https://github.com/GetStream/apple-internal-testing-pipeline), which pins this SDK to that exact version and all other Stream SDKs to their latest released versions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved release automation by running integration tests after publishing releases.
  - Added Swift package linting to the release validation process.
  - Updated release tooling to support the latest publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->