### PR TITLE
Bump fastlane-plugin-stream_actions to 0.4.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,7 +206,7 @@ GEM
       bundler
       fastlane
       pry
-    fastlane-plugin-stream_actions (0.4.8)
+    fastlane-plugin-stream_actions (0.4.9)
       xctest_list (= 1.2.1)
     fastlane-plugin-versioning (0.7.1)
     fastlane-plugin-xcsize (1.2.0)
@@ -403,7 +403,7 @@ DEPENDENCIES
   danger-commit_lint
   fastlane
   fastlane-plugin-lizard
-  fastlane-plugin-stream_actions (= 0.4.8)
+  fastlane-plugin-stream_actions (= 0.4.9)
   fastlane-plugin-versioning
   fastlane-plugin-xcsize (= 1.2.0)
   json

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,5 +3,5 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-versioning'
-gem 'fastlane-plugin-stream_actions', '0.4.8'
+gem 'fastlane-plugin-stream_actions', '0.4.9'
 gem 'fastlane-plugin-xcsize', '1.2.0'


### PR DESCRIPTION
Fixes https://linear.app/stream/issue/IOS-1942

### 🎯 Goal

Fix TestFlight deploys failing at the changelog step when it contains text-presentation symbols like `⚠` (App Store Connect rejects them in `whatsNew`, and pilot's emoji stripper misses them).

### 📝 Summary

- Bump `fastlane-plugin-stream_actions` to 0.4.9, which strips all pictographs and their invisible companions from the TestFlight changelog before upload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Fastlane plugin to the latest available patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->